### PR TITLE
Added PKConstant to support Appear.in as a new type of External Meeting.

### DIFF
--- a/PodioKit/Support/PKConstants.h
+++ b/PodioKit/Support/PKConstants.h
@@ -648,9 +648,11 @@ static NSString * const kPKNotificationTypeParticipation = @"participation";
 typedef enum {
   PKExternalMeetingTypeNone = 0,
   PKExternalMeetingTypeGoToMeeting,
+  PKExternalMeetingTypeAppearIn,
 } PKExternalMeetingType;
 
 static NSString * const kPKExternalMeetingTypeGoToMeeting = @"gotomeeting";
+static NSString * const kPKExternalMeetingTypeAppearIn = @"appear_in";
 
 typedef NS_ENUM(NSUInteger, PKMeetingParticipantStatus) {
   PKMeetingParticipantStatusNone,

--- a/PodioKit/Support/PKConstants.m
+++ b/PodioKit/Support/PKConstants.m
@@ -821,6 +821,8 @@
   
   if ([string isEqualToString:kPKExternalMeetingTypeGoToMeeting]) {
     type = PKExternalMeetingTypeGoToMeeting;
+  } else if ([string isEqualToString:kPKExternalMeetingTypeAppearIn]) {
+    type = PKExternalMeetingTypeAppearIn;
   }
   
   return type;


### PR DESCRIPTION
This update to the 1.x SDK is required for Appear.in support in release 5.1.2