### PR TITLE
Fix bug preventing saving items containing calculation fields

### DIFF
--- a/PodioKit/Common/Models/PKTItem.m
+++ b/PodioKit/Common/Models/PKTItem.m
@@ -284,8 +284,18 @@
       __block PKTAsyncTask *saveTask = nil;
 
       NSArray *itemFields = [self allFieldsToSaveForApp:app];
+
+      // Filter out all fields of type PKTAppFieldTypeCalculation because
+      // if you updating an existing item containing one, it will 
+      // cause an error: "Values cannot be set directly for field with id <FIELD-ID-NUMBER>"
+      NSMutableArray *mutItemFields = [NSMutableArray new];
+      for (PKTItemField* field in itemFields) {
+        if ([field type] != PKTAppFieldTypeCalculation) {
+          [mutItemFields addObject:field]
+        }
+      }
       [client performBlock:^{
-        saveTask = [self saveWithItemFields:itemFields];
+        saveTask = [self saveWithItemFields:mutItemFields];
       }];
       
       return saveTask;

--- a/PodioKit/Common/Models/PKTItem.m
+++ b/PodioKit/Common/Models/PKTItem.m
@@ -291,7 +291,7 @@
       NSMutableArray *mutItemFields = [NSMutableArray new];
       for (PKTItemField* field in itemFields) {
         if ([field type] != PKTAppFieldTypeCalculation) {
-          [mutItemFields addObject:field]
+          [mutItemFields addObject:field];
         }
       }
       [client performBlock:^{


### PR DESCRIPTION
The `save` method in `PKTItem` is modified to filter out all fields of type `PKTAppFieldTypeCalculation` because if you updating an existing item containing one, it will  cause an error: "Values cannot be set directly for field with id <FIELD-ID-NUMBER>"